### PR TITLE
Remove deprecated strictCalls parameter

### DIFF
--- a/includes/strict-rules/level.7.neon
+++ b/includes/strict-rules/level.7.neon
@@ -1,6 +1,2 @@
-parameters:
-    strictRules:
-        strictCalls: true
-
 includes:
     - level.6.neon


### PR DESCRIPTION
strictCalls was removed in phpstan/phpstan-strict-rules 2.x (renamed to strictFunctionCalls). Setting it causes "Unexpected item" error with PHPStan 2.x. The rule is enabled by default so removing the explicit true has no effect on 1.x.
<img width="474" height="136" alt="image" src="https://github.com/user-attachments/assets/9a344753-c75e-485b-9ccb-4c60757566fb" />
