### PR TITLE
remove param strictCalls from level 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- remove param strictCalls from level 7, as it is not supported in phpstan-strict-rules 2.0
 
 ## [0.19.7] - 2025-01-12
 ### Fixed

--- a/includes/strict-rules/level.7.neon
+++ b/includes/strict-rules/level.7.neon
@@ -1,6 +1,2 @@
-parameters:
-    strictRules:
-        strictCalls: true
-
 includes:
     - level.6.neon


### PR DESCRIPTION
remove param strictCalls from level 7, as it is not supported in phpstan-strict-rules 2.0